### PR TITLE
fix: specify `exports` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"type": "module",
 	"module": "index.js",
+	"exports": "./index.js",
 	"scripts": {
 		"postinstall": "husky || true",
 		"prepack": "pinst --disable",


### PR DESCRIPTION
This PR adds the `exports` field to `package.json` to avoid deprecation warnings.

## Description

I keep getting deprecation notice [DEP0151](https://nodejs.org/api/deprecations.html#dep0151-main-index-lookup-and-extension-searching) when using the `stylelint-header` package. This seems to be related due to a missing `main` or `exports` field in `package.json`. That's why I added the `exports` field which solves the issue.

## Related issue(s)

- #86

## How has this been tested?

I tested this manually, see steps in related issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes.