### PR TITLE
feat: add opt-out for special comment format (#142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --dev stylelint-header
 
 #### templateVariables
 
-Type `object`; Default {}
+Type `object`; Default `{}`
 
 This is an object of key/value pairs that will be used to replace variables in the header template. For example, if you have a header template that looks like this:
 
@@ -56,9 +56,15 @@ This plugin is using [lodash.template](https://lodash.com/docs/4.17.15#template)
 
 #### nonMatchingTolerance
 
-Type `numeric`; Default 0.98
+Type `numeric`; Default `0.98`
 
 This is a number between 0 and 1 representing the percentage of allowed difference between a found comment in the file and the provided header. Uses [`string-similarity`](https://www.npmjs.com/package/string-similarity) to determine value.
+
+#### isRemovable
+
+Type `boolean`; Default `false`
+
+This setting determines whether the comment starts with `/*!`, a special syntax that is often retained even when other comments are stripped by minifiers such as cssnano. If set to `true`, copyright comments will be added with `/*` only; by default all comments use `/*!`.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -35,8 +35,9 @@ const meta = {
 
 /**
  * @typedef {object} Options
- * @property {number} nonMatchingTolerance
- * @property {{ [string]: any }} templateVariables
+ * @property {number} [nonMatchingTolerance=0.98] -- percentage of allowed difference between a found comment in the file and the provided header
+ * @property {{ [string]: any }} [templateVariables={}] -- used to replace variables in the header template
+ * @property {boolean} [isRemovable=false] -- whether the comment starts with `/*!`, a special syntax that is often retained even when other comments are stripped by minifiers such as cssnano
  */
 
 /** @type {import('stylelint').Rule<string, Options>} */
@@ -63,6 +64,7 @@ const ruleFunction =
 						(val) => typeof val === "number" && val >= 0 && val <= 1,
 					],
 					templateVariables: [Object, null],
+					isRemovable: [Boolean, null],
 				},
 			},
 		);
@@ -91,6 +93,7 @@ const ruleFunction =
 		});
 
 		const nonMatchingTolerance = options?.nonMatchingTolerance || 0.98;
+		const isRemovable = options?.isRemovable || false;
 
 		// Walk comments on root to find if header exists
 		let found = false;
@@ -124,7 +127,7 @@ const ruleFunction =
 					.map((line) => ` * ${line}`)
 					.join("\n"),
 				raws: {
-					left: "!\n",
+					left: isRemovable ? "\n" : "!\n",
 					right: "\n ",
 				},
 			});

--- a/test/fixed-removable.css
+++ b/test/fixed-removable.css
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Adobe.
+ */
+
+.foo {
+	position: relative;
+}

--- a/test/pass-removable.css
+++ b/test/pass-removable.css
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Adobe.
+ */
+
+.foo {
+	position: relative;
+}

--- a/test/stylelint-header.test.js
+++ b/test/stylelint-header.test.js
@@ -155,3 +155,36 @@ testRule({
 		},
 	],
 });
+
+/** @description Test case to validate removable tests */
+testRule({
+	plugins,
+	ruleName,
+	config: [
+		join("test", "input.txt"),
+		{
+			nonMatchingTolerance: 1,
+			templateVariables: {
+				company: "Adobe",
+			},
+			isRemovable: true,
+		},
+	],
+	fix: true,
+
+	accept: [
+		{
+			code: readFileSync(join("test", "pass-removable.css"), { encoding: "utf-8" }),
+			description: "Simple CSS with header included in a removable comment",
+		},
+	],
+
+	reject: [
+		{
+			code: readFileSync(join("test", "fail.css"), { encoding: "utf-8" }),
+			fixed: readFileSync(join("test", "fixed-removable.css"), { encoding: "utf-8" }),
+			description: "Auto-fix file missing header with removable comment",
+			message: messages.rejected,
+		},
+	],
+});


### PR DESCRIPTION
## Description

Add a new feature to opt-out of the special comment format. The `/*!` prefix protects comments from being stripped during minification to retain copyright details however this is not always desired for all projects. By adding the `isRemovable` flag, users can opt-out of persistent comment format.

## Related issue(s)

- Related to #142 

## How has this been tested?

-   [x] _Test suite added to verify the removal of the ! in the copyright comment during fix_

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes.
