### PR TITLE
chore: update domain from allons-y.llc to allons-y.studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "3.0.0",
 	"description": "A stylelint plugin that checks for a file header.",
 	"license": "Apache-2.0",
-	"author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+	"author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/castastrophe/stylelint-header.git"


### PR DESCRIPTION
## What
Update domain references from `allons-y.llc` to `allons-y.studio`.

## Why
Studio rebrand — the `.llc` domain is being retired in favour of `.studio`.

## How
Find-and-replace author URL in `package.json`.

## Test plan
Verified no remaining `allons-y.llc` references in source files (excluding `.git` and `node_modules`).

## Checklist
- [x] My code follows the project's style and conventions.
- [x] I have performed a self-review of my changes.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] My changes generate no new warnings or accessibility regressions.
- [x] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
