### PR TITLE
docs: use scoped package name in README install and config examples

### DIFF
--- a/.changeset/scope-package-name-in-readme.md
+++ b/.changeset/scope-package-name-in-readme.md
@@ -1,0 +1,5 @@
+---
+"@allons-y/stylelint-header": patch
+---
+
+Use the scoped package name `@allons-y/stylelint-header` in the README install commands and stylelint `plugins` config examples. The bare `stylelint-header` name would fail to install and leave stylelint unable to resolve the plugin now that the package lives under the allons-y org.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Copyright and licence headers are easy to add and easy to forget. A pre-commit l
 ## Installation
 
 ```sh
-yarn add --dev stylelint-header
-npm install --save-dev stylelint-header
-pnpm add --save-dev stylelint-header
-bun add --dev stylelint-header
+yarn add --dev @allons-y/stylelint-header
+npm install --save-dev @allons-y/stylelint-header
+pnpm add --save-dev @allons-y/stylelint-header
+bun add --dev @allons-y/stylelint-header
 ```
 
 ## Usage
@@ -63,7 +63,7 @@ Add the plugin to your stylelint config and enable the `header/header` rule, pas
 
 ```json
 {
-	"plugins": ["stylelint-header"],
+	"plugins": ["@allons-y/stylelint-header"],
 	"rules": {
 		"header/header": ["./COPYRIGHT"]
 	}
@@ -74,7 +74,7 @@ Add the plugin to your stylelint config and enable the `header/header` rule, pas
 
 ```js
 {
-  "plugins": ["stylelint-header"],
+  "plugins": ["@allons-y/stylelint-header"],
   "rules": {
     "header/header": [
       "Copyright <%= YEAR %>. <%= company %>",


### PR DESCRIPTION
## Description

The README install commands (yarn/npm/pnpm/bun) and the two stylelint `plugins` config examples still referenced the bare `stylelint-header` name. Now that the package is published as `@allons-y/stylelint-header` under the allons-y org, those instructions fail to install the package and leave stylelint unable to resolve the plugin. Updated all six references to the scoped name.

Repo URLs, the test filename, and changelog history intentionally keep the bare name — they are not the package identifier. The auto-generated Weaver banner `<h1>` and the prose display name were left untouched.

## Related issue(s)

- Closes #284

## Motivation and context

Following the org move, users copying the README's install/config snippets would hit install failures and an unresolvable plugin.

## How has this been tested?

- [x] `yarn test` — 44 tests pass (also run by the pre-commit hook)
- [x] Manual review of every `stylelint-header` occurrence to confirm only package-identifier usages were changed

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

A changeset (`patch`) is included.